### PR TITLE
Adding Post Transactions

### DIFF
--- a/src/routes/postTransactions.test.ts
+++ b/src/routes/postTransactions.test.ts
@@ -1,0 +1,31 @@
+import { postTransactions } from './postTransactions';
+import { badRequest, accepted } from '../utils/httpResponses';
+
+jest.mock('../utils/httpResponses');
+
+test('bad Request', async () => {
+    const req = {
+      body: [
+        {}, //invalid
+      ],
+    };
+    const res = 'res';
+    postTransactions(req, res);
+  
+    expect(badRequest).toHaveBeenCalledWith(res, 'Invalid transactions present');
+  });
+  
+  test('good request', async () => {
+    const req = {
+      body: [
+        {external_id: 13, amount: 13, description:'test'},
+        {external_id: 13, amount: 13, description:'test'},
+      ],
+    };
+    const res = 'res';
+    postTransaction(req, res);
+  
+    expect(badRequest).not.toHaveBeenCalled();
+    expect(accepted).toHaveBeenCalledWith(res);
+    expect(saveTransaction).toHaveBeenCalledTimes(2);
+  })

--- a/src/routes/postTransactions.test.ts
+++ b/src/routes/postTransactions.test.ts
@@ -1,5 +1,6 @@
 import { postTransactions } from './postTransactions';
 import { badRequest, accepted } from '../utils/httpResponses';
+import { recordTransaction } from '../data/recordTransaction';
 
 jest.mock('../utils/httpResponses');
 
@@ -27,5 +28,5 @@ test('bad Request', async () => {
   
     expect(badRequest).not.toHaveBeenCalled();
     expect(accepted).toHaveBeenCalledWith(res);
-    expect(saveTransaction).toHaveBeenCalledTimes(2);
+    expect(recordTransaction).toHaveBeenCalledTimes(2);
   })

--- a/src/routes/postTransactions.ts
+++ b/src/routes/postTransactions.ts
@@ -1,0 +1,56 @@
+import { Response } from 'express'
+import { badRequest, accepted } from '../utils/httpResponses';
+import { Transaction } from '../data/Transaction';
+import { hash } from '../utils/hash';
+import { recordTransaction } from '../data/recordTransaction';
+import { TransactionRequest } from './TransactionRequest';
+
+export interface PostedTransaction {
+    externalId: number;
+    amount: number;
+    description: string;
+}
+
+export const postTransactions = async (req: TransactionRequest<PostedTransaction[]>, res: Response): Promise<void> => {
+    let good: Transaction[] = [],
+    bad: PostedTransaction[] = [];
+  validateTransactions(req.body, good, bad);
+
+  if (bad.length > 0) {
+    badRequest(res, 'Invalid transactions present');
+    return;
+  }
+
+  if (good.length > 0) {
+    good.forEach(async t => {
+      await recordTransaction(t, req.user.id);
+    });
+    return accepted(res);
+  }
+};
+
+export const validateTransactions = (transactions: PostedTransaction[], good: Transaction[], bad: PostedTransaction[]): void => {
+    for (let i = 0; i < transactions.length; i++) {
+      const t = transactions[i];
+      if (t.externalId == NaN) {
+        t.externalId = parseInt(t.externalId);
+        if (t.externalId == NaN) {
+          bad.push(t);
+          continue;
+        }
+      }
+  
+      if (t.amount == 0) {
+        bad.push(t);
+        continue;
+      }
+  
+      if (!t.description) {
+        bad.push(t);
+        continue;
+      }
+  
+      (t as Transaction).internalId = hash(t.externalId + '###' + t.amount + '!!!' + t.description);
+      good.push((t as Transaction));
+    }
+  };


### PR DESCRIPTION
# Requirements:

- Receive an array of transactions, each with a numerical `externalId` , positive `amount`, and a string `description`.
- generate an `internalId` by hashing the passed values.
- save the transactions using the defined `recordTransaction` function.
- If *any* of the posted transactions are invalid, reject the entire batch.